### PR TITLE
Fix auth filter throwing an exception before Spring servlet

### DIFF
--- a/backend/src/main/java/com/demo/language_booking/auth/authentication/AuthenticationValidationFilter.java
+++ b/backend/src/main/java/com/demo/language_booking/auth/authentication/AuthenticationValidationFilter.java
@@ -110,7 +110,8 @@ public class AuthenticationValidationFilter extends OncePerRequestFilter {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        if(handle == null) throw new NullPointerException();
+        // Null handle can only occur if the endpoint doesn't exist. Return and forward it to Spring.
+        if(handle == null) return false;
         Method endpointMethod = ((HandlerMethod) handle.getHandler()).getMethod();
         return securedEndpoints.contains(endpointMethod.toGenericString());
     }


### PR DESCRIPTION
Whenever we didn't find the method handler e.g. a non-existent API endpoint; it would throw an exception. Now we declare the endpoint as not secured and let Spring handle it.